### PR TITLE
Fixed a race condition when "not X"=>Array

### DIFF
--- a/Kate.php
+++ b/Kate.php
@@ -661,7 +661,6 @@ abstract class Kate {
 					}
 				}
 			}
-			else if(is_array($value) && sizeof($value)) $select->where($field.' IN('.$db->quote($value).')');
 			elseif($field == 'group by') {
 				$select->group($this->_getTableFieldName($value));
 			}
@@ -679,6 +678,7 @@ abstract class Kate {
 				else if(!empty($value)) $select->where('LOWER('.$field.') = ?',strtolower($value));
 				
 			}
+			else if(is_array($value) && sizeof($value)) $select->where($field.' IN('.$db->quote($value).')');
 			elseif(isset($value) && $this->_isTableField($fieldName)) $select->where($field.' = ?',$value);
 			
 		}


### PR DESCRIPTION
I was trying to do:
$items = $Model->getItems(array('field1'=>$value1, 'not field2' => Array(0)));

It seems like you can't use an Array() as a value when a "not" operator is applied on field2.
The error comes from a race condition where the value being an array is evaluated before the "not" operator check, resulting in an Internal Error.
